### PR TITLE
Fix LocationCondition schema

### DIFF
--- a/i3-policy-store.yaml
+++ b/i3-policy-store.yaml
@@ -576,24 +576,27 @@ components:
             - location
           properties:
             location:
-              type: object
-              required:
-                - lo
-                - profile
-                - label
-                - lang
-              properties:
-                lo:
-                  type: string
-                profile:
-                  type: string
-                  enum: [civic, geodetic]
-                label:
-                  type: string
-                lang:
-                  type: string
-                extension:
-                  type: object
+              type: array
+              minItems: 1
+              items:
+                type: object
+                required:
+                  - lo
+                  - profile
+                  - label
+                  - lang
+                properties:
+                  lo:
+                    type: string
+                  profile:
+                    type: string
+                    enum: [civic, geodetic]
+                  label:
+                    type: string
+                  lang:
+                    type: string
+                  extension:
+                    type: object
             extension:
               type: object
     CallSuspicionCondition:


### PR DESCRIPTION
According to `NENA-STA-010.3e-2021_i3_Stan.pdf`, `LocationCondition` is defined as follows:

> The “LocationCondition” object MUST contain **at least one “location” child object**.

That means multiple "location" child objects may be supplied. OpenAPI schema has been updated to account for that.

@babley FYI