### PR TITLE
Fix CapCondition schema

### DIFF
--- a/i3-policy-store.yaml
+++ b/i3-policy-store.yaml
@@ -793,18 +793,35 @@ components:
         - $ref: '#/components/schemas/Condition'
         - type: object
           required:
-            - tag
+            - elements
           properties:
-            tag:
-              type: string
-              enum: [Identifier, Sender, Address, InfoEventCode, InfoValueName]
-            operator:
-              type: string
-              enum: [EQ, SS, NE]
-            content:
-              type: string
+            elements:
+              type: object
+              minProperties: 1
+              properties:
+                identifier:
+                  $ref: '#/components/schemas/CapConditionChild'
+                sender:
+                  $ref: '#/components/schemas/CapConditionChild'
+                address:
+                  $ref: '#/components/schemas/CapConditionChild'
+                infoEventCode:
+                  $ref: '#/components/schemas/CapConditionChild'
+                infoValueName:
+                  $ref: '#/components/schemas/CapConditionChild'
             nonInteractive:
               type: boolean
+    CapConditionChild:
+      type: object
+      required:
+        - operator
+        - content
+      properties:
+        operator:
+          type: string
+          enum: [EQ, SS, NE]
+        content:
+          type: string
     CallingNumberVerificationStatusCondition:
       allOf:
         - $ref: '#/components/schemas/Condition'

--- a/i3-policy-store.yaml
+++ b/i3-policy-store.yaml
@@ -793,30 +793,25 @@ components:
         - $ref: '#/components/schemas/Condition'
         - type: object
           required:
-            - elements
+            - tests
           properties:
-            elements:
-              type: object
-              minProperties: 1
-              properties:
-                identifier:
-                  $ref: '#/components/schemas/CapConditionChild'
-                sender:
-                  $ref: '#/components/schemas/CapConditionChild'
-                address:
-                  $ref: '#/components/schemas/CapConditionChild'
-                infoEventCode:
-                  $ref: '#/components/schemas/CapConditionChild'
-                infoValueName:
-                  $ref: '#/components/schemas/CapConditionChild'
+            tests:
+              type: array
+              minItems: 1
+              items:
+                $ref: '#/components/schemas/CapConditionTest'
             nonInteractive:
               type: boolean
-    CapConditionChild:
+    CapConditionTest:
       type: object
       required:
+        - tag
         - operator
         - content
       properties:
+        tag:
+          type: string
+          enum: [Identifier, Sender, Address, InfoEventCode, InfoValueName]
         operator:
           type: string
           enum: [EQ, SS, NE]


### PR DESCRIPTION
Fix CapCondition schema based on the NENA-STA-010.3e-2021_i3_Stan.pdf definition.

According to the standard, `CapCondition` may have more than one child object:

> The above child objects are OPTIONAL, but at least one MUST occur. **Multiple child objects
MAY occur within a “CapCondition” object**; they are interpreted with an implicit logical
AND: if any evaluate to ‘false, the condition evaluates to ‘false.

There are various ways to represent this using OpenAPI schema. This PR proposed the solution that also allows to enforce the "at least one MUST occur" requirement.

FYI @babley